### PR TITLE
URL field form validation

### DIFF
--- a/app/start/page.tsx
+++ b/app/start/page.tsx
@@ -34,8 +34,8 @@ const promptSuggestions = [
 ];
 
 const generateFormSchema = z.object({
-  url: z.string(),
-  prompt: z.string().max(160),
+  url: z.string().min(1),
+  prompt: z.string().min(3).max(160),
 });
 
 type GenerateFormValues = z.infer<typeof generateFormSchema>;


### PR DESCRIPTION
* Previously, URL field was not validated which meant users could submit by pressing prompt suggestion with no URL
* Added validation for the prompt field as well

<img width="1119" alt="Screenshot 2023-09-20 at 10 20 57 PM" src="https://github.com/Nutlope/qrGPT/assets/6607077/611bc362-b780-41cd-9d1e-c305f96e29b4">
